### PR TITLE
Fix `cssnano({safe: true})` only works for the first file

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (opts) {
             var error = 'Streaming not supported';
             return cb(new PluginError(PLUGIN_NAME, error));
         } else if (file.isBuffer()) {
-            nano.process(String(file.contents), assign(opts, {
+            nano.process(String(file.contents), assign({}, opts, {
                 map: (file.sourceMap) ? {annotation: false} : false,
                 from: file.relative,
                 to: file.relative


### PR DESCRIPTION
Below is the source code in [cssnano](https://github.com/ben-eb/cssnano/blob/master/src/index.js)
~~~javascript
if (options.safe === true) {
    options.isSafe = true;
    options.safe = null;
}
~~~
In order to use `safe` mode, we cannot pass the original `options`