### PR TITLE
Drop deprecated dependency gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var nano        = require('cssnano'),
     assign      = require('object-assign'),
-    PluginError = require('gulp-util').PluginError,
+    PluginError = require('plugin-error'),
     Transform   = require('stream').Transform,
     applySourceMap = require('vinyl-sourcemaps-apply'),
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "devDependencies": {
     "gulp-sourcemaps": "^1.5.2",
     "tap-spec": "^4.0.2",
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "vinyl": "^2.1.0"
   },
   "homepage": "https://github.com/ben-eb/gulp-cssnano",
   "author": {
@@ -31,8 +32,8 @@
   "repository": "ben-eb/gulp-cssnano",
   "dependencies": {
     "cssnano": "^3.0.0",
-    "gulp-util": "^3.0.6",
     "object-assign": "^4.0.1",
+    "plugin-error": "^1.0.1",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "files": [

--- a/test.js
+++ b/test.js
@@ -2,8 +2,8 @@
 
 var test = require('tape');
 var nano = require('./');
-var gutil = require('gulp-util');
-var Stream = require('stream');
+var Vinyl = require('vinyl');
+var ReadableStream = require('stream').Readable;
 var sourcemaps = require('gulp-sourcemaps');
 
 var css = 'h1\n{\n    color: white\n}\n';
@@ -12,7 +12,7 @@ var expected = 'h1{color:#fff}';
 var sourceMapRegex = /sourceMappingURL=data:application\/json;/;
 
 function fixture (contents) {
-    return new gutil.File({
+    return new Vinyl({
         contents: contents,
         cwd: __dirname,
         base: __dirname,
@@ -79,7 +79,7 @@ test('should throw an error in stream mode', function (t) {
 
     var stream = nano();
 
-    var file = fixture(new Stream());
+    var file = fixture(new ReadableStream());
 
     var write = function () {
         stream.write(file);


### PR DESCRIPTION
Closes ben-eb/gulp-cssnano#92
Supersedes ben-eb/gulp-cssnano#93
