### PR TITLE
test: only test on supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - '5'
-  - '4'
-  - '0.12'
+  - lts/boron
+  - lts/carbon
+  - lts/dubnium
+  - node


### PR DESCRIPTION
BREAKING CHANGE:
Tells TravisCI to run tests on supported NodeJS versions. The full
release and support schedule can be found on the NodeJS website:
https://github.com/nodejs/Release#release-schedule.  Node 6.x is still
in maintenance LTS until April 2019.

By dropping unsupported versions, we are able to keep pace with the
css-nano library newer versions and addresses the errors in #104.

I recommend the library release version be bumped to reflect the 
breaking nature of this change.